### PR TITLE
Fix for #65

### DIFF
--- a/lib/FileAPI.Form.js
+++ b/lib/FileAPI.Form.js
@@ -92,16 +92,18 @@
 					queue.inc();
 					file.blob.toBlob(function (blob){
 						data.name = file.name;
-						data.file =  blob;
-						data.size =  blob.length;
+						data.file = blob;
+						data.size = blob.length;
+						data.type = file.type;
 						queue.next();
 					}, 'image/png');
 				}
 				else if( file.file ){
 				    //file
 					data.name = file.blob.name;
-					data.file =  file.blob;
-					data.size =  file.blob.size;
+					data.file = file.blob;
+					data.size = file.blob.size;
+					data.type = file.type;
 				}
 				else {
 				    // additional data

--- a/lib/FileAPI.XHR.js
+++ b/lib/FileAPI.XHR.js
@@ -204,6 +204,7 @@
 
 					xhr.setRequestHeader("Content-Range", "bytes " + data.start + "-" + data.end + "/" + data.size);
 					xhr.setRequestHeader("Content-Disposition", 'attachment; filename=' + encodeURIComponent(data.name));
+					xhr.setRequestHeader("Content-Type", data.type || "application/octet-stream");
                     
 					slice = data.file[slice](data.start, data.end + 1);
                  


### PR DESCRIPTION
Added "Content-Type" header

Example of server-side response for preflight cors request

``` java
response.setHeader("Access-Control-Allow-Origin", "*");
if ("options".equals(req.getMethod().toLowerCase())) {
    response.addHeader("Access-Control-Request-Method", "POST");
    response.addHeader("Access-Control-Allow-Headers", "Content-Range, X-Requested-With, Content-Disposition, Content-Type");

    return null;
}
```
