### PR TITLE
Fixed network down recovery

### DIFF
--- a/lib/FileAPI.Form.js
+++ b/lib/FileAPI.Form.js
@@ -112,8 +112,8 @@
 				    }
 				    data.params.push(encodeURIComponent(file.name) + "=" + encodeURIComponent(file.blob));
 				}
-				data.start = 0;
-				data.end = 0;
+				data.start = -1;
+				data.end = -1;
 				data.retry = 0;
 			});
 		},

--- a/lib/FileAPI.XHR.js
+++ b/lib/FileAPI.XHR.js
@@ -169,13 +169,21 @@
 							}
 							xhr.onreadystatechange = null;
                             
-							if (xhr.status - 201 > 0) {
+							if (!xhr.status || xhr.status - 201 > 0) {
 								// some kind of error
-								if (++data.retry <= options.chunkUploadRetry && (500 == xhr.status || 416 == xhr.status)) {
+								// 0 - connection fail or timeout
+								// 201 and up - server error
+								if (++data.retry <= options.chunkUploadRetry && (!xhr.status || 500 == xhr.status || 416 == xhr.status)) {
 									// let's try again the same chunk
 									// only applicable for recoverable error codes 500 && 416 
-									data.end = data.start
-									_this._send(options, data);
+
+									var to = xhr.status ? 0
+														: api.chunkNetworkDownRetryTimeout;
+
+									data.end = data.start - 1;
+									setTimeout(function () {
+									    _this._send(options, data);
+									}, to);
 								} else {
 									// no mo retries
 									_this.end(xhr.status);
@@ -189,15 +197,17 @@
 									_this.end(xhr.status);
 								} else {
 									// next chunk
-									_this._send(options, data);
+									setTimeout(function () {
+									    _this._send(options, data);
+									}, 0);
 								}
 							}
 							xhr = null;
 						}
 					};
 
-					data.start = data.end;
-					data.end = Math.min(data.end + options.chunkSize, data.size ) - 1;
+					data.start = data.end + 1;
+					data.end = Math.min(data.start + options.chunkSize, data.size ) - 1;
                     
 					var slice;
 					(slice = 'slice') in data.file || (slice = 'mozSlice') in data.file || (slice = 'webkitSlice') in data.file;

--- a/lib/FileAPI.core.js
+++ b/lib/FileAPI.core.js
@@ -71,6 +71,7 @@
 			
 			chunkSize : 0,
 			chunkUploadRetry : 0,
+			chunkNetworkDownRetryTimeout : 2000, // milliseconds, don't flood when network is down
 
 			KB: (_KB.from = _from, _KB),
 			MB: (_MB.from = _from, _MB),


### PR DESCRIPTION
This patch fixes chunk size calculation during network down retries and prevents library from flooding with upload requests.
