### PR TITLE
removed additional pixels from width and height

### DIFF
--- a/lib/FileAPI.Flash.js
+++ b/lib/FileAPI.Flash.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * FileAPI fallback to Flash
  *
  * @flash-developer  "Vladimir Demidov" <v.demidov@corp.mail.ru>
@@ -143,8 +143,8 @@
 							_css(dummy, {
 								  top:    0
 								, left:   0
-								, width:  target.offsetWidth + 100
-								, height: target.offsetHeight + 100
+								, width:  target.offsetWidth
+								, height: target.offsetHeight
 								, zIndex: 1e6+'' // set max zIndex
 								, position: 'absolute'
 							});


### PR DESCRIPTION
Remove additional width and height from mouseover. 

I think all styling and positioning should be handled with CSS not like this inside the script.
The clearest solution should be just to add a class "hover" to the element. The developer can make it look like its needed in the current layout of the form.
