### PR TITLE
Consider phantomjs and casperjs headless browser as html5 compatible

### DIFF
--- a/lib/FileAPI.core.js
+++ b/lib/FileAPI.core.js
@@ -25,7 +25,7 @@
 		jQuery = window.jQuery,
 
 		html5 =    !!(File && (FileReader && (window.Uint8Array || FormData || XMLHttpRequest.prototype.sendAsBinary)))
-				&& !(/safari\//i.test(userAgent) && !/chrome\//i.test(userAgent) && /windows/i.test(userAgent)), // BugFix: https://github.com/mailru/FileAPI/issues/25
+				&& !(/safari\//i.test(userAgent) && !/chrome\//i.test(userAgent) && /windows/i.test(userAgent) && !/casperjs\//i.test(userAgent) && !/phantomjs\//i.test(userAgent)), // BugFix: https://github.com/mailru/FileAPI/issues/25
 
 		cors = html5 && ('withCredentials' in (new XMLHttpRequest)),
 		


### PR DESCRIPTION
phantomjs is webkit based and should be considered as html5 compliant.

Not sure if exception in user agent html5 control should be added like that, specially as you can choose agent in those headless browser but i tought maybe someone would like that fix
