### PR TITLE
Remove '_'+file.name

### DIFF
--- a/lib/FileAPI.Form.js
+++ b/lib/FileAPI.Form.js
@@ -138,10 +138,6 @@
 				else {
 					data.append(file.name, file.blob);
 				}
-
-				if( file.file ){
-					data.append('_'+file.name, file.file);
-				}
 			});
 		},
 


### PR DESCRIPTION
Why Form.prototype.toFormData appends '_'+file.name?

When upload request body looks like:

------WebKitFormBoundary13nJwlOAdYFVK3qi
Content-Disposition: form-data; name="file"; filename="949A0453.JPG"
Content-Type: image/jpeg

------WebKitFormBoundary13nJwlOAdYFVK3qi
Content-Disposition: form-data; name="_file"

949A0453.JPG
------WebKitFormBoundary13nJwlOAdYFVK3qi--
