### PR TITLE
Remove a console.log in jquery.fileapi.js

### DIFF
--- a/plugins/jquery.fileapi.js
+++ b/plugins/jquery.fileapi.js
@@ -541,8 +541,6 @@
 				this._$fileprogress = $progress = this.$elem('file.progress', $file);
 			}
 
-			console.log(uid, ui, $file);
-
 			if( type == 'progress' ){
 				$progress.stop().animate({ width: ui.loaded/ui.total*100 + '%' }, 300);
 			}


### PR DESCRIPTION
The console.log call breaks old versions of IE.
