### PR TITLE
Отключить проверку на размер в байтах при drag-and-drop в Safari

### DIFF
--- a/lib/FileAPI.core.js
+++ b/lib/FileAPI.core.js
@@ -11,6 +11,7 @@
 		document = window.document,
 		doctype = document.doctype || {},
 		userAgent = window.navigator.userAgent,
+		safari = /safari\//i.test(userAgent) && !/chrome\//i.test(userAgent),
 
 		// https://github.com/blueimp/JavaScript-Load-Image/blob/master/load-image.js#L48
 		apiURL = (window.createObjectURL && window) || (window.URL && URL.revokeObjectURL && URL) || (window.webkitURL && webkitURL),
@@ -25,7 +26,7 @@
 		jQuery = window.jQuery,
 
 		html5 =    !!(File && (FileReader && (window.Uint8Array || FormData || XMLHttpRequest.prototype.sendAsBinary)))
-				&& !(/safari\//i.test(userAgent) && !/chrome\//i.test(userAgent) && /windows/i.test(userAgent)), // BugFix: https://github.com/mailru/FileAPI/issues/25
+				&& !(safari && /windows/i.test(userAgent)), // BugFix: https://github.com/mailru/FileAPI/issues/25
 
 		cors = html5 && ('withCredentials' in (new XMLHttpRequest)),
 
@@ -1443,7 +1444,7 @@
 
 	function _isRegularFile(file, callback){
 		// http://stackoverflow.com/questions/8856628/detecting-folders-directories-in-javascript-filelist-objects
-		if( !file.type && (file.size % 4096) === 0 && (file.size <= 102400) ){
+		if( !file.type && (safari || ((file.size % 4096) === 0 && (file.size <= 102400))) ){
 			if( FileReader ){
 				try {
 					var Reader = new FileReader();


### PR DESCRIPTION
[Проверка размера в байтах](https://github.com/mailru/FileAPI/blob/master/lib/FileAPI.core.js#L1446) всегда ложна в Safari 8.0.3 OSX Yosemite 10.10.2
```js
(file.size % 4096) === 0 && (file.size <= 102400)
```
Поэтому по событию drop в Safari FileAPI отдает папки, которые невозможно отличить от неизвестных файлов.

Дополнил проверку следующим образом:
```js
safari || ((file.size % 4096) === 0 && (file.size <= 102400))
```