### PR TITLE
fix mailru/FileAPI#314 malformed entry.name (OSX Unicode NFD)

### DIFF
--- a/lib/FileAPI.core.js
+++ b/lib/FileAPI.core.js
@@ -32,6 +32,8 @@
 
 		chunked = html5 && !!Blob && !!(Blob.prototype.webkitSlice || Blob.prototype.mozSlice || Blob.prototype.slice),
 
+		normalize = ('' + ''.normalize).indexOf('[native code]') > 0,
+
 		// https://github.com/blueimp/JavaScript-Canvas-to-Blob
 		dataURLtoBlob = window.dataURLtoBlob,
 
@@ -702,16 +704,61 @@
 			getDropFiles: function (evt, callback){
 				var
 					  files = []
+					, items = []
 					, dataTransfer = _getDataTransfer(evt)
-					, entrySupport = _isArray(dataTransfer.items) && dataTransfer.items[0] && _getAsEntry(dataTransfer.items[0])
+					, transFiles = dataTransfer.files
+					, transItems = dataTransfer.items
+					, entrySupport = _isArray(transItems) && transItems[0] && _getAsEntry(transItems[0])
 					, queue = api.queue(function (){ callback(files); })
 				;
 
-				_each((entrySupport ? dataTransfer.items : dataTransfer.files) || [], function (item){
+				if( entrySupport ){
+					if( normalize && transFiles ){
+						var
+							i = transFiles.length
+							, file
+							, entry
+						;
+
+						items = new Array(i);
+						while( i-- ){
+							file = transFiles[i];
+
+							try {
+								entry = _getAsEntry(transItems[i]);
+							}
+							catch( err ){
+								api.log('[err] getDropFiles: ', err);
+								entry = null;
+							}
+
+							if( _isEntry(entry) ){
+								// OSX filesystems use Unicode Normalization Form D (NFD),
+								// and entry.file(…) can't read the files with the same names
+								if ( entry.isDirectory || (entry.isFile && file.name == file.name.normalize('NFC')) ) {
+									items[i] = entry;
+								} else {
+									items[i] = file;
+								}
+							}
+							else {
+								items[i] = file;
+							}
+						}
+					}
+					else {
+						items = transItems;
+					}
+				}
+				else {
+					items = transFiles;
+				}
+
+				_each(items, function (item){
 					queue.inc();
 
 					try {
-						if( entrySupport ){
+						if( entrySupport && _isEntry(item) ){
 							_readEntryAsFiles(item, function (err, entryFiles){
 								if( err ){
 									api.log('[err] getDropFiles:', err);
@@ -1469,6 +1516,11 @@
 		else {
 			callback(true);
 		}
+	}
+
+
+	function _isEntry(item){
+		return item && (item.isFile || item.isDirectory);
 	}
 
 


### PR DESCRIPTION
Загрузку папок с Unicode NFD именами победить не удалось, но это не работает ни в Dropbox, ни в Google Drive.

Принцип фикса в следующем: вместо того чтобы итерировать конкретные массивы `dataTransfer.items` или `dataTransfer.files`, пытаем составить новый массив из этих двух.
Если  `entry` является файлом и его имя в формате Unicode NFC, значит кладем в новый массив `dataTransfer.items[i]`, иначе `dataTransfer.files[i]`.