### PR TITLE
Node.js fields and images

### DIFF
--- a/examples/webcam.html
+++ b/examples/webcam.html
@@ -116,11 +116,6 @@
 							FileAPI.upload({
 								  url: '/upload'
 								, files: { shot: file }
-								, data: {
-									x: 1,
-									arr: [1, {y: 1}],
-									y: "xxxxxx"
-								}
 								, complete: function (err, xhr){
 									var res = JSON.parse(xhr.responseText);
 									var img = new Image;

--- a/examples/webcam.html
+++ b/examples/webcam.html
@@ -116,6 +116,11 @@
 							FileAPI.upload({
 								  url: '/upload'
 								, files: { shot: file }
+								, data: {
+									x: 1,
+									arr: [1, {y: 1}],
+									y: "xxxxxx"
+								}
 								, complete: function (err, xhr){
 									var res = JSON.parse(xhr.responseText);
 									var img = new Image;

--- a/node/file-api.js
+++ b/node/file-api.js
@@ -1,43 +1,44 @@
 
 function convertToBase64(buffer, mimetype) {
-  return 'data:' + mimetype + ';base64,' + buffer.toString('base64');
+	return 'data:' + mimetype + ';base64,' + buffer.toString('base64');
 }
 
 function fileApi() {
-  return function (req, res, next) {
-    req.body = {};
-    req.files = {};
-    req.images = {};
+	return function (req, res, next) {
+		req.body = {};
+		req.files = {};
+		req.images = {};
 
-    req.busboy.on('file', function (fieldname, file, filename, encoding, mimetype) {
-      var buffersArray = [];
+		req.busboy.on('file', function (fieldname, file, filename, encoding, mimetype) {
+			var buffersArray = [];
 
-      file.on('data', function (data) {
-        buffersArray.push(data);
-      });
+			file.on('data', function (data) {
+				buffersArray.push(data);
+			});
 
-      file.on('end', function () {
-        var bufferResult = Buffer.concat(buffersArray);
-        var fileObj = {
-          dataURL: convertToBase64(bufferResult, mimetype),
-          mime: mimetype,
-          size: bufferResult.length
-        };
-        req.files[fieldname] = fileObj;
-        if (mimetype.indexOf('image/') === 0) {
-          req.images[fieldname] = fileObj;
-        }
-      });
-    });
+			file.on('end', function () {
+				var bufferResult = Buffer.concat(buffersArray);
+				var fileObj = {
+					dataURL: convertToBase64(bufferResult, mimetype),
+					mime: mimetype,
+					size: bufferResult.length
+				};
+				req.files[fieldname] = fileObj;
+				if (mimetype.indexOf('image/') === 0) {
+					req.images[fieldname] = fileObj;
+				}
+			});
+		});
 
-    req.busboy.on('field', function (key, value, keyTruncated, valueTruncated) {
-      req.body[key] = value;
-    });
+		req.busboy.on('field', function (key, value, keyTruncated, valueTruncated) {
+			req.body[key] = value;
+			console.log(arguments);
+		});
 
-    req.busboy.on('finish', function () {
-      next();
-    });
-  };
+		req.busboy.on('finish', function () {
+			next();
+		});
+	};
 }
 
 module.exports = fileApi;

--- a/node/file-api.js
+++ b/node/file-api.js
@@ -7,6 +7,7 @@ function fileApi() {
   return function (req, res, next) {
     req.body = {};
     req.files = {};
+    req.images = {};
 
     req.busboy.on('file', function (fieldname, file, filename, encoding, mimetype) {
       var buffersArray = [];
@@ -17,11 +18,15 @@ function fileApi() {
 
       file.on('end', function () {
         var bufferResult = Buffer.concat(buffersArray);
-        req.body.files[fieldname] = {
+        var fileObj = {
           dataURL: convertToBase64(bufferResult, mimetype),
           mime: mimetype,
           size: bufferResult.length
         };
+        req.files[fieldname] = fileObj;
+        if (mimetype.indexOf('image/') === 0) {
+          req.images[fieldname] = fileObj;
+        }
       });
     });
 

--- a/node/file-api.js
+++ b/node/file-api.js
@@ -1,13 +1,16 @@
 
+var qs = require('qs');
+
 function convertToBase64(buffer, mimetype) {
 	return 'data:' + mimetype + ';base64,' + buffer.toString('base64');
 }
 
 function fileApi() {
 	return function (req, res, next) {
-		req.body = {};
 		req.files = {};
 		req.images = {};
+
+		var queryString = '';
 
 		req.busboy.on('file', function (fieldname, file, filename, encoding, mimetype) {
 			var buffersArray = [];
@@ -30,12 +33,12 @@ function fileApi() {
 			});
 		});
 
-		req.busboy.on('field', function (key, value, keyTruncated, valueTruncated) {
-			req.body[key] = value;
-			console.log(arguments);
+		req.busboy.on('field', function (key, value) {
+			queryString += encodeURIComponent(key) + '=' + encodeURIComponent(value) + '&';
 		});
 
 		req.busboy.on('finish', function () {
+			req.body = qs.parse(queryString);
 			next();
 		});
 	};

--- a/node/server.js
+++ b/node/server.js
@@ -32,7 +32,7 @@ app.post(uploadPath, busboy({immediate: true}), fileApi(), function (req, res) {
   res[jsonp ? 'jsonp' : 'json']({
     status:     200,
     statusText: 'OK',
-    images:     req.files,
+    images:     req.images,
     data: {
 		HEADERS: req.headers,
 		_REQUEST: req.body,

--- a/node/server.js
+++ b/node/server.js
@@ -6,45 +6,50 @@ var app = express();
 app.use(express.static('.', {index: 'index.html'}));
 
 app.use(function (req, res, next) {
-  // Enable CORS for non static files
-  var origin = req.get('Origin');
+	// Enable CORS for non static files
+	var origin = req.get('Origin');
 
-  if (origin) {
-    res.set({
-      'Access-Control-Allow-Origin':      origin,
-      'Access-Control-Allow-Methods':     'POST, GET, OPTIONS',
-      'Access-Control-Allow-Headers':     'Origin, X-Requested-With, Content-Range, Content-Disposition, Content-Type, X-Foo, X-Rnd',
-      'Access-Control-Allow-Credentials': 'true'
-    });
-  }
-  next();
+	if (origin) {
+		res.set({
+			'Access-Control-Allow-Origin': origin,
+			'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+			'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Range, Content-Disposition, Content-Type, X-Foo, X-Rnd',
+			'Access-Control-Allow-Credentials': 'true'
+		});
+	}
+	next();
 });
 
 var uploadPath = '/upload';
 
 app.options(uploadPath, function (req, res) {
-  res.end();
+	res.end();
 });
 
-app.post(uploadPath, busboy({immediate: true}), fileApi(), function (req, res) {
-  var jsonp = req.query.callback || null;
+app.post(
+	uploadPath,
+	busboy({immediate: true}), 					// parse post data
+	fileApi(),									// prepare req.body, req.files and req.images
+	function (req, res) {
+		var jsonp = req.query.callback || null;
 
-  res[jsonp ? 'jsonp' : 'json']({
-    status:     200,
-    statusText: 'OK',
-    images:     req.images,
-    data: {
-		HEADERS: req.headers,
-		_REQUEST: req.body,
-		_FILES: req.files
+		res[jsonp ? 'jsonp' : 'json']({
+			status: 200,
+			statusText: 'OK',
+			images: req.images,
+			data: {
+				HEADERS: req.headers,
+				_REQUEST: req.body,
+				_FILES: req.files
+			}
+		});
 	}
-  });
-});
+);
 
 var server = app.listen(8000, function () {
 
-  var host = server.address().address;
-  var port = server.address().port;
+	var host = server.address().address;
+	var port = server.address().port;
 
-  console.log('Test server listening at http://%s:%s', host, port)
+	console.log('Test server listening at http://%s:%s', host, port)
 });

--- a/node/server.js
+++ b/node/server.js
@@ -28,8 +28,8 @@ app.options(uploadPath, function (req, res) {
 
 app.post(
 	uploadPath,
-	busboy({immediate: true}), 					// parse post data
-	fileApi(),									// prepare req.body, req.files and req.images
+	busboy({immediate: true}),	// parse post data
+	fileApi(),					// prepare req.body, req.files and req.images
 	function (req, res) {
 		var jsonp = req.query.callback || null;
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "grunt-mxmlc": "~0.5.1",
     "grunt-version": "~0.3.0",
     "phantomjs": "~1.9.7-9",
+    "qs": "~2.4.1",
     "semver": "~2.3.1 ",
     "temporary": "~0.0.8"
   },


### PR DESCRIPTION
1) перевел все на табы :)
2) в req.images - только картинки, в req.files - все файлы
3) fields разбираются почти как в php, c той лишь разницей, что если придет объект только с числовыми ключами, то он будет интерпретирован, как массив:
```javascript
var query = 'a[3]=3&a[1]=1&a[5]=5';
qs.parse(query); // [1, 3, 5]
```
