### PR TITLE
Remove duplicate HTML5 script from Bower main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,6 @@
     "./dist/FileAPI.flash.image.swf",
     "./dist/FileAPI.flash.swf",
     "./dist/FileAPI.html5.js",
-    "./dist/FileAPI.html5.min.js",
     "./dist/FileAPI.js",
     "./dist/jquery.fileapi.min.js"
   ],


### PR DESCRIPTION
With

```
 "./dist/FileAPI.html5.js",
 "./dist/FileAPI.html5.min.js",
```

GruntJS Wiredep task will include both files into the projects that use FileAPI. This could be ignored in Grunt task, but I think it would be nicer to remove duplication from the bower.json :)

After this change the bower package should be updated also.