### PR TITLE
fix mailru/FileAPI#318 store all dropped items

### DIFF
--- a/lib/FileAPI.core.js
+++ b/lib/FileAPI.core.js
@@ -704,12 +704,13 @@
 			getDropFiles: function (evt, callback){
 				var
 					  files = []
-					, items = []
+					, all = []
+					, items
 					, dataTransfer = _getDataTransfer(evt)
 					, transFiles = dataTransfer.files
 					, transItems = dataTransfer.items
 					, entrySupport = _isArray(transItems) && transItems[0] && _getAsEntry(transItems[0])
-					, queue = api.queue(function (){ callback(files); })
+					, queue = api.queue(function (){ callback(files, all); })
 				;
 
 				if( entrySupport ){
@@ -735,9 +736,10 @@
 							if( _isEntry(entry) ){
 								// OSX filesystems use Unicode Normalization Form D (NFD),
 								// and entry.file(…) can't read the files with the same names
-								if ( entry.isDirectory || (entry.isFile && file.name == file.name.normalize('NFC')) ) {
+								if( entry.isDirectory || (entry.isFile && file.name == file.name.normalize('NFC')) ){
 									items[i] = entry;
-								} else {
+								}
+								else {
 									items[i] = file;
 								}
 							}
@@ -754,23 +756,32 @@
 					items = transFiles;
 				}
 
-				_each(items, function (item){
+				_each(items || [], function (item){
 					queue.inc();
 
 					try {
 						if( entrySupport && _isEntry(item) ){
-							_readEntryAsFiles(item, function (err, entryFiles){
+							_readEntryAsFiles(item, function (err, entryFiles, allEntries){
 								if( err ){
 									api.log('[err] getDropFiles:', err);
 								} else {
 									files.push.apply(files, entryFiles);
 								}
+								all.push.apply(all, allEntries);
+
 								queue.next();
 							});
 						}
 						else {
-							_isRegularFile(item, function (yes){
-								yes && files.push(item);
+							_isRegularFile(item, function (yes, err){
+								if( yes ){
+									files.push(item);
+								}
+								else {
+									item.error = err;
+								}
+								all.push(item);
+
 								queue.next();
 							});
 						}
@@ -1494,23 +1505,26 @@
 		if( !file.type && (safari || ((file.size % 4096) === 0 && (file.size <= 102400))) ){
 			if( FileReader ){
 				try {
-					var Reader = new FileReader();
+					var reader = new FileReader();
 
-					_one(Reader, _readerEvents, function (evt){
+					_one(reader, _readerEvents, function (evt){
 						var isFile = evt.type != 'error';
-						callback(isFile);
 						if( isFile ){
-							Reader.abort();
+							reader.abort();
+							callback(isFile);
+						}
+						else {
+							callback(false, reader.error);
 						}
 					});
 
-					Reader.readAsDataURL(file);
+					reader.readAsDataURL(file);
 				} catch( err ){
-					callback(false);
+					callback(false, err);
 				}
 			}
 			else {
-				callback(null);
+				callback(null, new Error('FileReader is not supported'));
 			}
 		}
 		else {
@@ -1535,34 +1549,52 @@
 	function _readEntryAsFiles(entry, callback){
 		if( !entry ){
 			// error
-			callback('invalid entry');
+			var err = new Error('invalid entry');
+			entry = new Object(entry);
+			entry.error = err;
+			callback(err.message, [], [entry]);
 		}
 		else if( entry.isFile ){
 			// Read as file
-			entry.file(function(file){
+			entry.file(function (file){
 				// success
 				file.fullPath = entry.fullPath;
-				callback(false, [file]);
+				callback(false, [file], [file]);
 			}, function (err){
 				// error
-				callback('FileError.code: '+err.code);
+				entry.error = err;
+				callback('FileError.code: ' + err.code, [], [entry]);
 			});
 		}
 		else if( entry.isDirectory ){
-			var reader = entry.createReader(), result = [];
+			var
+				reader = entry.createReader()
+				, firstAttempt = true
+				, files = []
+				, all = [entry]
+			;
 
-			var onerror = function() {
+			var onerror = function (err){
 				// error
-				callback('directory_reader');
+				entry.error = err;
+				callback('DirectoryError.code: ' + err.code, files, all);
 			};
-			var ondone = function ondone(entries) {
+			var ondone = function ondone(entries){
+				if( firstAttempt ){
+					firstAttempt = false;
+					if( !entries.length ){
+						entry.error = new Error('directory is empty');
+					}
+				}
+
 				// success
-				if ( entries.length ) {
+				if( entries.length ){
 					api.afor(entries, function (next, entry){
-						_readEntryAsFiles(entry, function (err, files){
+						_readEntryAsFiles(entry, function (err, entryFiles, allEntries){
 							if( !err ){
-								result = result.concat(files);
+								files = files.concat(entryFiles);
 							}
+							all = all.concat(allEntries);
 
 							if( next ){
 								next();
@@ -1574,7 +1606,7 @@
 					});
 				}
 				else {
-					callback(false, result);
+					callback(false, files, all);
 				}
 			};
 


### PR DESCRIPTION
В callback, который передается в `getDropFiles`, приходит вторым параметром список всех файлов и папок, которые перетащил пользователь.
У ошибочных элементов есть свойство `error` – ссылка на инстанс ошибки.

```js
FileAPI.getDropFiles(function (files, all) {

    var failed = all.filter(function (anything) {
        return anything.error;
    });

    failed[0].name // 'йод.docx'
    failed[0].error.message // 'A URI supplied to the API was malformed, or the resulting Data URL has exceeded the URL length limitations for Data URLs.'

});
```

https://github.com/mailru/FileAPI/issues/318