### PR TITLE
Increased flash z-index to 2147483647

### DIFF
--- a/lib/FileAPI.Flash.js
+++ b/lib/FileAPI.Flash.js
@@ -77,7 +77,7 @@
 									, width: 5
 									, height: 5
 									, position: 'absolute'
-									, zIndex: 1e6+'' // set max zIndex
+									, zIndex: 2147483647+'' // set max zIndex
 								});
 
 								child.parentNode.insertBefore(dummy, child);
@@ -188,7 +188,7 @@
 									, left:   0
 									, width:  target.offsetWidth
 									, height: target.offsetHeight
-									, zIndex: 1e6+'' // set max zIndex
+									, zIndex: 2147483647+'' // set max zIndex
 									, position: 'absolute'
 								});
 


### PR DESCRIPTION
I've recently had problems getting FileAPI to use Flash. Although Flash was being detected and the flash uploader inserted on the page, FileAPI was falling back to using an iFrame for submission. After investigating further, it turns out that the flash uploader was being hidden behind other elements. FileAPI uses a z-index of 1000000, but apparently some of our elements are even higher than that (don't ask why). To resolve this, I've increased the z-index to 2^32, which I believe is the maximum that both legacy and new browsers will accept (see http://www.puidokas.com/max-z-index/). This resolves the problem for me, and now FileAPI successfully uses the flash uploader.