### PR TITLE
Add error handling to image parsing & filename fix for multipart data

### DIFF
--- a/dist/FileAPI.html5.js
+++ b/dist/FileAPI.html5.js
@@ -1349,7 +1349,7 @@
 					, queue = api.queue(function (){ fn(Form); })
 					, isOrignTrans = trans && _isOriginTransform(trans)
 					, postNameConcat = api.postNameConcat
-					, invalidImage = options.invalidImage || api.F
+					, invalidImage = options.complete || api.F
 				;
 
 				// Append data
@@ -1371,7 +1371,7 @@
 						file.toData(function (err, image){
 							// @todo: требует рефакторинга и обработки ошибки
 							if( err ){
-								invalidImage(image);
+								invalidImage("Unable to process Image",{}, file, options);
 								return;
 							}
 							if (file.file) {

--- a/dist/FileAPI.html5.js
+++ b/dist/FileAPI.html5.js
@@ -2735,6 +2735,9 @@
 		toMultipartData: function (fn){
 			this._to([], fn, function (file, data, queue, boundary){
 				queue.inc();
+				if(!file.name || file.name == "undefined"){
+					file.name = "file"
+				}
 				_convertFile(file, function (file, blob){
 					data.push(
 						  '--_' + boundary + ('\r\nContent-Disposition: form-data; name="'+ file.name +'"'+ (file.file ? '; filename="'+ encodeURIComponent(file.file) +'"' : '')

--- a/dist/FileAPI.html5.js
+++ b/dist/FileAPI.html5.js
@@ -1349,6 +1349,7 @@
 					, queue = api.queue(function (){ fn(Form); })
 					, isOrignTrans = trans && _isOriginTransform(trans)
 					, postNameConcat = api.postNameConcat
+					, invalidImage = options.invalidImage || api.F
 				;
 
 				// Append data
@@ -1369,6 +1370,10 @@
 
 						file.toData(function (err, image){
 							// @todo: требует рефакторинга и обработки ошибки
+							if( err ){
+								invalidImage(image);
+								return;
+							}
 							if (file.file) {
 								image.type = file.file.type;
 								image.quality = file.matrix.quality;

--- a/dist/FileAPI.js
+++ b/dist/FileAPI.js
@@ -1369,6 +1369,10 @@
 
 						file.toData(function (err, image){
 							// @todo: требует рефакторинга и обработки ошибки
+							if( err ){
+								options.invalidImage(image);
+								return;
+							}
 							if (file.file) {
 								image.type = file.file.type;
 								image.quality = file.matrix.quality;

--- a/dist/FileAPI.js
+++ b/dist/FileAPI.js
@@ -2735,6 +2735,9 @@
 		toMultipartData: function (fn){
 			this._to([], fn, function (file, data, queue, boundary){
 				queue.inc();
+				if(!file.name || file.name == "undefined"){
+					file.name = "file"
+				}
 				_convertFile(file, function (file, blob){
 					data.push(
 						  '--_' + boundary + ('\r\nContent-Disposition: form-data; name="'+ file.name +'"'+ (file.file ? '; filename="'+ encodeURIComponent(file.file) +'"' : '')

--- a/dist/FileAPI.js
+++ b/dist/FileAPI.js
@@ -1349,6 +1349,7 @@
 					, queue = api.queue(function (){ fn(Form); })
 					, isOrignTrans = trans && _isOriginTransform(trans)
 					, postNameConcat = api.postNameConcat
+					, invalidImage = options.complete || api.F
 				;
 
 				// Append data
@@ -1370,7 +1371,7 @@
 						file.toData(function (err, image){
 							// @todo: требует рефакторинга и обработки ошибки
 							if( err ){
-								options.invalidImage(image);
+								invalidImage("Unable to process Image",{}, file, options);
 								return;
 							}
 							if (file.file) {


### PR DESCRIPTION
I found that there was no good handling for corrupt or unreadable image files, (like a text file mislabled as a .jpg), so this handling seems to work well, assuming the client can catch the errors gracefully. (my project worked with no changes, since I already had error handling in the `complete()` function)

In my testing, I also found that the filename would sometimes come through as undefined, the cause appeared to be due to uploading preview images that had been scaled and cropped. (Lost metadata?) This patch fixed my uploads to Amazon S3.