### PR TITLE
Move grunt-cli to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "express": "~4.12.3",
     "flex-sdk": "^4.6.0-0",
     "grunt": "^0.4.5",
+    "grunt-cli": "^1.3.2",
     "grunt-contrib-compress": "~0.9.1",
     "grunt-contrib-concat": "~0.4.0",
     "grunt-contrib-connect": "~0.8.0",
@@ -56,7 +57,5 @@
     "Mikhail Bezoyan <mbezoyan@gmail.com>"
   ],
   "license": "BSD",
-  "dependencies": {
-    "grunt-cli": "^1.3.2"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
grunt-cli throws error on install, if no local grunt is installed - 
![image](https://user-images.githubusercontent.com/16723746/91858146-7795ff80-ec71-11ea-9044-6f9d765e0158.png)

And grunt-cli is not truly needed to use the package


