### PR TITLE
docs: Fix simple typo, mexapixel -> megapixel

### DIFF
--- a/dist/FileAPI.html5.js
+++ b/dist/FileAPI.html5.js
@@ -2440,7 +2440,7 @@
     loadImage.detectSubsampling = function (img) {
         var canvas,
             context;
-        if (img.width * img.height > 1024 * 1024) { // only consider mexapixel images
+        if (img.width * img.height > 1024 * 1024) { // only consider megapixel images
             canvas = document.createElement('canvas');
             canvas.width = canvas.height = 1;
             context = canvas.getContext('2d');

--- a/dist/FileAPI.js
+++ b/dist/FileAPI.js
@@ -2440,7 +2440,7 @@
     loadImage.detectSubsampling = function (img) {
         var canvas,
             context;
-        if (img.width * img.height > 1024 * 1024) { // only consider mexapixel images
+        if (img.width * img.height > 1024 * 1024) { // only consider megapixel images
             canvas = document.createElement('canvas');
             canvas.width = canvas.height = 1;
             context = canvas.getContext('2d');


### PR DESCRIPTION
There is a small typo in dist/FileAPI.html5.js, dist/FileAPI.js.

Should read `megapixel` rather than `mexapixel`.

